### PR TITLE
Made some optimizations

### DIFF
--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreIT.java
@@ -94,7 +94,6 @@ public class OracleEmbeddingStoreIT {
         OracleEmbeddingStore embeddingStore = OracleEmbeddingStore.builder()
                 .table(tableName)
                 .dataSource(dataSource)
-                .batchSize(2)
                 .dimension(384)
                 .useIndex(true)
                 .createTable(true)


### PR DESCRIPTION
This branch is making some optimizations to the existing OracleEmbeddingStore:
- We convert directly between `float[]` and VECTOR data. Removed intermediate `oracle.sql.VECTOR` objects and `double[]`
- We use Statement.addBatch(String) to initialize our table. This allows JDBC to pipeline the DDL statements.
- In the delete method, the `IN` clause is replaced with a batch `DELETE`. The `IN` clause may not work if the ID list is large enough.
- We use OracleStatement.defineColumnType to avoid an extra round trip when querying a VECTOR column.
- We don't use a batchSize limit. There is no need to do this with 23.4, where memory usage is greatly optimized for batch inserts.

Please leave review comments for any change which you'd like to know more about. Happy to discuss more.