### PR TITLE
Added Oracle embedding store

### DIFF
--- a/docs/docs/integrations/embedding-stores/index.md
+++ b/docs/docs/integrations/embedding-stores/index.md
@@ -19,6 +19,7 @@ sidebar_position: 0
 | [MongoDB Atlas](/integrations/embedding-stores/mongodb-atlas)                         | ✅                |                       |                     |
 | [Neo4j](/integrations/embedding-stores/neo4j)                                         |                  |                       |                     |
 | [OpenSearch](/integrations/embedding-stores/opensearch)                               | ✅                |                       |                     |
+| [Oracle](/integrations/embedding-stores/oracle)                                       | ✅                | ✅                     | ✅                   |
 | [PGVector](/integrations/embedding-stores/pgvector)                                   | ✅                | ✅                     | ✅                   |
 | [Pinecone](/integrations/embedding-stores/pinecone)                                   |                  |                       |                     |
 | [Qdrant](/integrations/embedding-stores/qdrant)                                       | ✅                |                       |                     |

--- a/docs/docs/integrations/embedding-stores/oracle.md
+++ b/docs/docs/integrations/embedding-stores/oracle.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 13
+---
+
+# Oracle
+The Oracle Embedding Store integrates with
+the [AI Vector Search Feature](https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/overview-ai-vector-search.html) of Oracle Database.
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-oracle</artifactId>
+    <version>0.31.0</version>
+</dependency>
+```
+
+## APIs
+
+- `OracleEmbeddingStore`
+
+
+## Examples
+
+- [OracleEmbeddingStoreExample](https://github.com/langchain4j/langchain4j-examples/blob/main/oracle-example/src/main/java/OracleEmbeddingStoreExample.java)

--- a/docs/docs/integrations/embedding-stores/pgvector.md
+++ b/docs/docs/integrations/embedding-stores/pgvector.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # PGVector

--- a/docs/docs/integrations/embedding-stores/pinecone.md
+++ b/docs/docs/integrations/embedding-stores/pinecone.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # Pinecone

--- a/docs/docs/integrations/embedding-stores/qdrant.md
+++ b/docs/docs/integrations/embedding-stores/qdrant.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # Qdrant

--- a/docs/docs/integrations/embedding-stores/redis.md
+++ b/docs/docs/integrations/embedding-stores/redis.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # Redis

--- a/docs/docs/integrations/embedding-stores/vearch.md
+++ b/docs/docs/integrations/embedding-stores/vearch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # Vearch

--- a/docs/docs/integrations/embedding-stores/vespa.md
+++ b/docs/docs/integrations/embedding-stores/vespa.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # Vespa

--- a/docs/docs/integrations/embedding-stores/weaviate.md
+++ b/docs/docs/integrations/embedding-stores/weaviate.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # Weaviate


### PR DESCRIPTION
Added Oracle to the list of embedding store integrations. I verified the changes by building the docs with "docasaurus" as described in docs/README.md.

There is a link to example code which will 404 until we actually push it to the examples repo. I think we need to get the embedding store merged into the project before we can add the example. 