### PR TITLE
Adds the possibility to create other type of indexes.

### DIFF
--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/DatabaseIndexBuilder.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/DatabaseIndexBuilder.java
@@ -8,24 +8,20 @@ import dev.langchain4j.store.embedding.oracle.CreateOption;
 public interface DatabaseIndexBuilder {
 
   /**
-   * Generates a SQL statement that can be used to create an index on the specified
-   * table and column.
+   * Generates a SQL statement that can be used to create an index on the {@link EmbeddingTable}
    *
-   * @param tableName The name of the table the index should be created on.
-   * @param columnName The name of the column to be indexed.
    * @return The SQL statement allowing to create the index on specified table
    * and columns.
    */
-  public abstract String getCreateStatement(String tableName, String columnName);
+  public String getCreateStatement();
 
   /**
-   * Generates a SQL statement that can be used to drop an index on the specified
+   * Generates a SQL statement that can be used to drop an index on the {@link EmbeddingTable}
    * table.
    *
-   * @param tableName the name of the table
    * @return A SQL statement that can be used to drop the index.
    */
-  String getDropStatement(String tableName);
+  String getDropStatement();
 
 }
 

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/EmbeddingTable.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/EmbeddingTable.java
@@ -86,7 +86,7 @@ public final class EmbeddingTable {
     /** Name of a column which stores metadata. */
     private final String metadataColumn;
 
-    private final DatabaseIndexBuilder vectorIndexBuilder;
+    private final VectorIndexBuilder vectorIndexBuilder;
 
     private EmbeddingTable(Builder builder) {
         createOption = ensureNotNull(builder.createOption, "createOption");
@@ -116,8 +116,9 @@ public final class EmbeddingTable {
                     + "PRIMARY KEY (" + idColumn + "))");
 
             if (vectorIndexBuilder != null) {
-                String dropStatement = vectorIndexBuilder.getDropStatement(name);
-                String createStatement = vectorIndexBuilder.getCreateStatement(name, embeddingColumn);
+                vectorIndexBuilder.setEmbeddingTable(this);
+                String dropStatement = vectorIndexBuilder.getDropStatement();
+                String createStatement = vectorIndexBuilder.getCreateStatement();
                 if (dropStatement != null) {
                     statement.addBatch(dropStatement);
                 }

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/IndexBuilder.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/IndexBuilder.java
@@ -1,0 +1,135 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.UnaryOperator;
+
+/**
+ * Use this class to create indexes in other columns of the {@link EmbeddingTable} than
+ * the embedding column. This class can be used to create an index in one or many
+ * columns and on one or many keys of the metadata column of the {@link EmbeddingTable}.
+ */
+public class IndexBuilder implements DatabaseIndexBuilder {
+  private final EmbeddingTable embeddingTable;
+
+  private final UnaryOperator<String> metadataKeyMapper;
+
+  private String indexName;
+
+  private boolean isUnique;
+
+  private boolean isBitmap;
+
+  private CreateOption createOption = CreateOption.CREATE_IF_NOT_EXISTS;
+
+  public final List<String> indexExpressions = new ArrayList<String>();
+
+  protected IndexBuilder(EmbeddingTable embeddingTable, UnaryOperator<String> metadataKeyMapper) {
+    this.embeddingTable = embeddingTable;
+    this.metadataKeyMapper = metadataKeyMapper;
+    this.indexName = embeddingTable.name() + UUID.randomUUID();
+  }
+
+  public enum Order {
+    ASC,
+    DESC
+  }
+
+  /**
+   * Configures the option to create (or not create) an index. The default is
+   * {@link CreateOption#CREATE_IF_NOT_EXISTS}, which means that an index will
+   * be created if an index with the same name does not already exist.
+   *
+   * @param createOption The create option.
+   *
+   * @return This builder.
+   */
+  public IndexBuilder createOption(CreateOption createOption) {
+    this.createOption = createOption;
+    return this;
+  }
+
+  /**
+   * Sets the name of the index, by defaut the name of the index will be the concatenation of the
+   * table name and a random {@link java.util.UUID}
+   * @param indexName The name of the index.
+   * @return This builder.
+   */
+  public IndexBuilder indexName(String indexName) {
+    this.indexName = indexName;
+    return this;
+  }
+
+  /**
+   * Specify UNIQUE to indicate that the value of the column (or columns) upon which the index is based must be unique.
+   * Note that you cannot specify both UNIQUE and BITMAP.
+   * @param isUnique True if the index should be UNIQUE otherwise false;
+   * @return This builder.
+   */
+  public IndexBuilder isUnique(boolean isUnique) {
+    this.isUnique = isUnique;
+    return this;
+  }
+
+  /**
+   * Specify BITMAP to indicate that index is to be created with a bitmap for each distinct key, rather than indexing each row separately.
+   * @param isBitmap True if the index should be BITMAP otherwise false;
+   * @return This builder.
+   */
+  public IndexBuilder isBitmap(boolean isBitmap) {
+    this.isBitmap = isBitmap;
+    return this;
+  }
+
+  /**
+   * Adds a column to the index expression of the index with the given order.
+   * @param column The column to index.
+   * @param order The order.
+   * @return This builder.
+   */
+  public IndexBuilder column(String column, Order order) {
+    indexExpressions.add(column + " " + order);
+    return this;
+  }
+
+  /**
+   * Adds a column expression to the index expression that allows to index the
+   * value of a given key of the JSON column.
+   * @param key The key to index.
+   * @param order The order.
+   * @return This builder
+   */
+  public IndexBuilder key(String key, Order order) {
+    indexExpressions.add(metadataKeyMapper.apply(key) + " " + order);
+    return this;
+  }
+
+
+  @Override
+  public String getCreateStatement() {
+    if (createOption == CreateOption.CREATE_NONE) {
+      return null;
+    }
+    return "CREATE " +
+        (isUnique ? " UNIQUE " : "") +
+        (isBitmap ? " BITMAP " : "") +
+        " INDEX " + indexName +
+        (createOption == CreateOption.CREATE_IF_NOT_EXISTS ? " IF NOT EXISTS " : "") +
+        " ON " + embeddingTable.name() +
+        "(" + getIndexExpression() + ")";
+  }
+
+  @Override
+  public String getDropStatement() {
+    if (createOption == CreateOption.CREATE_OR_REPLACE) {
+      return "DROP INDEX " + indexName;
+    }
+    return null;
+  }
+
+  private String getIndexExpression() {
+    return String.join(",", indexExpressions);
+  }
+
+}

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/UserDefinedIndexBuilder.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/UserDefinedIndexBuilder.java
@@ -1,0 +1,51 @@
+package dev.langchain4j.store.embedding.oracle;
+
+public class UserDefinedIndexBuilder implements DatabaseIndexBuilder {
+
+  private String createIndexStatement;
+  private String dropIndexStatement;
+
+  public UserDefinedIndexBuilder() {}
+
+  /**
+   * Creates a user defined index given a CREATE INDEX statement and a DROP INDEX statement. The DROP
+   * INDEX statement should only be provided if there is a need to drop the index before creating it.
+   * @param createIndexStatement The CREATE INDEX statement.
+   * @param dropIndexStatement The DROP INDEX statement or null if the INDEX should not be dropped
+   *                           before it is created.
+   */
+  public UserDefinedIndexBuilder(String createIndexStatement, String dropIndexStatement) {
+    this.createIndexStatement = createIndexStatement;
+    this.dropIndexStatement = dropIndexStatement;
+  }
+
+  /**
+   * Sets the CREATE INDEX statement.
+   * @param createIndexStatement The CREATE INDEX statement.
+   * @return This builder.
+   */
+  public UserDefinedIndexBuilder createIndexStatement (String createIndexStatement) {
+    this.createIndexStatement = createIndexStatement;
+    return this;
+  }
+
+  /**
+   * Sets the DROP INDEX statement.
+   * @param dropIndexStatement The DROP INDEX statement or null if the index should not be dropped.
+   * @return This builder.
+   */
+  public UserDefinedIndexBuilder dropIndexStatement (String dropIndexStatement) {
+    this.dropIndexStatement = dropIndexStatement;
+    return this;
+  }
+
+  @Override
+  public String getCreateStatement() {
+    return createIndexStatement;
+  }
+
+  @Override
+  public String getDropStatement() {
+    return dropIndexStatement;
+  }
+}


### PR DESCRIPTION
These changes add the possibility to create indexes on other columns of the embedding table. Two new DatabaseIndexBuilder implementations were added:

- UserDefinedIndexBuilder: allows to create an index by providing CREATE And DROP statements for the index.
- IndexBuilder: allows to create an index by adding columns or metadata keys to the list of index expressions to index. It uses the same matadataKeyMapper than the store to create the index expression for the key.

Added methods to the store to create new IndexBuilder and VectorIndexBuilder as well as a method to create indexes given an array of DatabaseIndexBuilders.