### PR TITLE
Updated pom for new ojdbc and langchain4j sync

### DIFF
--- a/langchain4j-oracle/pom.xml
+++ b/langchain4j-oracle/pom.xml
@@ -16,7 +16,7 @@
     <description>Oracle Database Embedding Store</description>
 
     <properties>
-        <jdbc.version>23.4.0.24.05</jdbc.version>
+        <jdbc.version>23.5.0.24.07</jdbc.version>
     </properties>
 
     <dependencies>
@@ -25,13 +25,13 @@
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <version>${jdbc.version}</version>
         </dependency>
 
+        <!-- Tests use the Universal Connection Pool as a JDBC DataSource -->
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ucp</artifactId>
@@ -39,6 +39,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Tests extend the integration tests from the core module -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
@@ -46,58 +47,57 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <!-- EmbeddingStoreIT tests use parameters -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
 
+        <!-- Tests use TestContainers to create an Oracle Database -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-free</artifactId>
             <scope>test</scope>
         </dependency>
 
+        <!-- SLF4J Logger used by various dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
@@ -105,6 +105,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Tests use this model to generate embeddings -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2-q</artifactId>

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
@@ -2,12 +2,11 @@ package dev.langchain4j.store.embedding.oracle;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.embedding.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingMatch;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import dev.langchain4j.store.embedding.EmbeddingStore;
-import oracle.jdbc.datasource.OracleDataSource;
 import oracle.sql.CHAR;
 import oracle.sql.CharacterSet;
 import oracle.ucp.jdbc.PoolDataSource;


### PR DESCRIPTION
Updates our pom.xml for compatibility with tests in the langchain4j-core module, after syncing up our branch. I also updated our import statement in CommonTestOperations to use the new package name for the embedding model.

I updated the Oracle JDBC version from 23.4 to 23.5. This is just to bring in our latest fixes and optimizations, I'm not aware of any which directly impacts the VECTOR data type though.