### PR TITLE
OracleContainer workaround to set timeout. Timeout set to 5mins.

### DIFF
--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
@@ -69,8 +69,8 @@ final class CommonTestOperations {
                 // The Ryuk component is relied upon to stop this container.
                 OracleContainer oracleContainer =
                     new OracleContainerWithTimeout("gvenzl/oracle-free:23.4-slim-faststart")
-                        .withStartupTimeoutSeconds(300)
-                        .withConnectTimeoutSeconds(300)
+                        .withStartupTimeoutSeconds(600)
+                        .withConnectTimeoutSeconds(600)
                         .withDatabaseName("pdb1")
                         .withUsername("testuser")
                         .withPassword("testpwd");

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
@@ -67,10 +67,13 @@ final class CommonTestOperations {
 
             if (urlFromEnv == null) {
                 // The Ryuk component is relied upon to stop this container.
-                OracleContainer oracleContainer = new OracleContainer("gvenzl/oracle-free:23.4-slim-faststart")
-                    .withDatabaseName("pdb1")
-                    .withUsername("testuser")
-                    .withPassword("testpwd");
+                OracleContainer oracleContainer =
+                    new OracleContainerWithTimeout("gvenzl/oracle-free:23.4-slim-faststart")
+                        .withStartupTimeoutSeconds(300)
+                        .withConnectTimeoutSeconds(300)
+                        .withDatabaseName("pdb1")
+                        .withUsername("testuser")
+                        .withPassword("testpwd");
                 oracleContainer.start();
 
                 DATA_SOURCE.setURL(oracleContainer.getJdbcUrl());

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleContainerWithTimeout.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleContainerWithTimeout.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.oracle.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+public class OracleContainerWithTimeout extends OracleContainer {
+
+  private int startupTimeoutSeconds = 60;
+
+  private int connectTimeoutSeconds = 60;
+
+  public OracleContainerWithTimeout(String dockerImageName) {
+    this(DockerImageName.parse(dockerImageName));
+  }
+
+  public OracleContainerWithTimeout(DockerImageName dockerImageName) {
+    super(dockerImageName);
+    waitingFor(
+        Wait
+            .forLogMessage(".*DATABASE IS READY TO USE!.*\\s", 1)
+            .withStartupTimeout(Duration.ofSeconds(startupTimeoutSeconds))
+    );
+    withConnectTimeoutSeconds(connectTimeoutSeconds);
+  }
+
+  @Override
+  public OracleContainer withStartupTimeoutSeconds(int startupTimeoutSeconds) {
+    this.startupTimeoutSeconds = startupTimeoutSeconds;
+    return super.withStartupTimeoutSeconds(startupTimeoutSeconds);
+  }
+
+  @Override
+  public OracleContainer withConnectTimeoutSeconds(int connectTimeoutSeconds) {
+    this.connectTimeoutSeconds = connectTimeoutSeconds;
+    return super.withConnectTimeoutSeconds(connectTimeoutSeconds);
+  }
+}

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleContainerWithTimeout.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleContainerWithTimeout.java
@@ -8,33 +8,17 @@ import java.time.Duration;
 
 public class OracleContainerWithTimeout extends OracleContainer {
 
-  private int startupTimeoutSeconds = 60;
-
-  private int connectTimeoutSeconds = 60;
-
   public OracleContainerWithTimeout(String dockerImageName) {
     this(DockerImageName.parse(dockerImageName));
   }
 
   public OracleContainerWithTimeout(DockerImageName dockerImageName) {
     super(dockerImageName);
-    waitingFor(
-        Wait
-            .forLogMessage(".*DATABASE IS READY TO USE!.*\\s", 1)
-            .withStartupTimeout(Duration.ofSeconds(startupTimeoutSeconds))
-    );
-    withConnectTimeoutSeconds(connectTimeoutSeconds);
   }
 
   @Override
   public OracleContainer withStartupTimeoutSeconds(int startupTimeoutSeconds) {
-    this.startupTimeoutSeconds = startupTimeoutSeconds;
+    this.waitStrategy.withStartupTimeout(Duration.ofSeconds(startupTimeoutSeconds));
     return super.withStartupTimeoutSeconds(startupTimeoutSeconds);
-  }
-
-  @Override
-  public OracleContainer withConnectTimeoutSeconds(int connectTimeoutSeconds) {
-    this.connectTimeoutSeconds = connectTimeoutSeconds;
-    return super.withConnectTimeoutSeconds(connectTimeoutSeconds);
   }
 }


### PR DESCRIPTION
Overrides OracleContainer to set startup and connection timeout. On OracleContainer they are set to 60s which cause the timeout in some cases.