### PR TITLE
Add warning to the log when an error occurs while creating the vector index. The store can be used without an index.

### DIFF
--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
@@ -16,6 +16,8 @@ import oracle.sql.json.OracleJsonFactory;
 import oracle.sql.json.OracleJsonObject;
 import oracle.sql.json.OracleJsonValue;
 import oracle.sql.json.OracleJsonValue.OracleJsonType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.*;
@@ -56,6 +58,7 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
  */
 public final class OracleEmbeddingStore implements EmbeddingStore<TextSegment> {
 
+    private static final Logger log = LoggerFactory.getLogger(OracleEmbeddingStore.class);
     /**
      * DataSource configured to connect with an Oracle Database.
      */
@@ -135,11 +138,14 @@ public final class OracleEmbeddingStore implements EmbeddingStore<TextSegment> {
                 statement.addBatch("DROP INDEX IF EXISTS " + indexName);
 
             statement.addBatch("CREATE VECTOR INDEX IF NOT EXISTS " + indexName +
-                        " ON " + tableName + "(" + builder.embeddingTable.embeddingColumn() + ")" +
-                        " ORGANIZATION NEIGHBOR PARTITIONS" +
+                " ON " + tableName + "(" + builder.embeddingTable.embeddingColumn() + ")" +
+                " ORGANIZATION NEIGHBOR PARTITIONS" +
                         " WITH DISTANCE " + builder.distanceMetric.name());
 
             statement.executeBatch();
+        } catch (SQLException sqlException) {
+            System.out.println("Error creating index: " + sqlException.getMessage());
+            log.warn("Error creating index: " + sqlException.getMessage(), sqlException);
         }
     }
 

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
@@ -138,8 +138,8 @@ public final class OracleEmbeddingStore implements EmbeddingStore<TextSegment> {
                 statement.addBatch("DROP INDEX IF EXISTS " + indexName);
 
             statement.addBatch("CREATE VECTOR INDEX IF NOT EXISTS " + indexName +
-                " ON " + tableName + "(" + builder.embeddingTable.embeddingColumn() + ")" +
-                " ORGANIZATION NEIGHBOR PARTITIONS" +
+                        " ON " + tableName + "(" + builder.embeddingTable.embeddingColumn() + ")" +
+                        " ORGANIZATION NEIGHBOR PARTITIONS" +
                         " WITH DISTANCE " + builder.distanceMetric.name());
 
             statement.executeBatch();

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStore.java
@@ -144,7 +144,6 @@ public final class OracleEmbeddingStore implements EmbeddingStore<TextSegment> {
 
             statement.executeBatch();
         } catch (SQLException sqlException) {
-            System.out.println("Error creating index: " + sqlException.getMessage());
             log.warn("Error creating index: " + sqlException.getMessage(), sqlException);
         }
     }


### PR DESCRIPTION
I believe this is an error on "CREATE VECTOR INDEX", the table name is quoted and should not be stored in upper case, but the database seems to be looking for a table with the name in upper case. This is just a workaround that adds a warning when an error occurs while creating the index because the store can work without an index. Not sure why this only happens with Unicode characters.