### PR TITLE
Explicit SQL types for SQLFilter 

### DIFF
--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/SQLFilters.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/SQLFilters.java
@@ -7,15 +7,15 @@ import dev.langchain4j.store.embedding.filter.logical.And;
 import dev.langchain4j.store.embedding.filter.logical.Not;
 import dev.langchain4j.store.embedding.filter.logical.Or;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.sql.*;
+import java.sql.SQLType;
 import java.util.*;
-import java.util.function.UnaryOperator;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A factory for {@link SQLFilter} implementations. The {@link #create(Filter, UnaryOperator)} creates a SQLFilter that
+ * A factory for {@link SQLFilter} implementations. The {@link #create(Filter, BiFunction)} creates a SQLFilter that
  * is equivalent to a given {@link Filter}.
  */
 final class SQLFilters {
@@ -73,20 +73,26 @@ final class SQLFilters {
 
 
     /**
+     * <p>
      * Returns a SQL filter that evaluates to the same result as a <code>Filter</code>.
+     * </p><p>
+     * A keyMapper function converts a {@link dev.langchain4j.data.document.Metadata} key into a SQL expression which
+     * results in the value of that key, as a specific SQL data type. The SQL expression returned by a mapping function
+     * might cast a column name to a specific type, as in "CAST(example AS VARCHAR)". The expression could also call the
+     * JSON_VALUE function, as in "JSON_VALUE(metadata, '$.example' RETURNING NUMERIC)".
+     * </p>
      *
      * @param filter Filter to replicate as a SQLFilter. May be null.
      *
-     * @param keyMapper Function which maps {@link dev.langchain4j.data.document.Metadata} keys to SQL identifiers.
-     *                  The SQL identifier can be a simple column name, or it can be a more complex expression, such
-     *                  as a call to the builtin "JSON_VALUE" function. This argument can not be null. The String
-     *                  passed to this function will not be null. This function must not return a null result.
+     * @param keyMapper Function which maps {@link dev.langchain4j.data.document.Metadata} keys to a SQL expression.
+     *                  This argument can not be null. The String and SQLType passed to this function will not be null.
+     *                  This function must not return null.
      *
      * @return The equivalent SQLFilter, which may be {@link #EMPTY} if the input <code>Filter</code> is null.
      *
      * @throws IllegalArgumentException If the class of the Filter is not recognized.
      */
-    static SQLFilter create(Filter filter, UnaryOperator<String> keyMapper) {
+    static SQLFilter create(Filter filter, BiFunction<String, SQLType, String> keyMapper) {
         if (filter == null)
             return EMPTY;
 
@@ -114,7 +120,7 @@ final class SQLFilters {
          *                  as a call to the builtin "JSON_VALUE" function. This argument can not be null. The String
          *                  passed to this function will not be null. This function must not return a null result.
          */
-        SQLFilter construct(Filter filter, UnaryOperator<String> keyMapper);
+        SQLFilter construct(Filter filter, BiFunction<String, SQLType, String> keyMapper);
     }
 
     /**
@@ -141,31 +147,37 @@ final class SQLFilters {
          */
         private final String sql;
 
+        /**
+         * The SQL data type that values are compared as. The comparison will operate on a key value and
+         * {@link #comparisonValue} that are converted to this SQL type.
+         */
+        private final SQLType sqlType;
+
         /** The right side operand. This is set as the value for the "?" parameter marker */
         private final Object comparisonValue;
 
-        SQLComparisonFilter(IsEqualTo isEqualTo, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isEqualTo.key()), "=", isEqualTo.comparisonValue(), false);
+        SQLComparisonFilter(IsEqualTo isEqualTo, BiFunction<String, SQLType, String> keyMapper) {
+            this(isEqualTo.key(), keyMapper, "=", isEqualTo.comparisonValue(), false);
         }
 
-        SQLComparisonFilter(IsNotEqualTo isNotEqualTo, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isNotEqualTo.key()), "<>", isNotEqualTo.comparisonValue(), true);
+        SQLComparisonFilter(IsNotEqualTo isNotEqualTo, BiFunction<String, SQLType, String> keyMapper) {
+            this(isNotEqualTo.key(), keyMapper, "<>", isNotEqualTo.comparisonValue(), true);
         }
 
-        SQLComparisonFilter(IsGreaterThan isGreaterThan, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isGreaterThan.key()), ">", isGreaterThan.comparisonValue(), false);
+        SQLComparisonFilter(IsGreaterThan isGreaterThan, BiFunction<String, SQLType, String> keyMapper) {
+            this(isGreaterThan.key(), keyMapper, ">", isGreaterThan.comparisonValue(), false);
         }
 
-        SQLComparisonFilter(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isGreaterThanOrEqualTo.key()), ">=", isGreaterThanOrEqualTo.comparisonValue(), false);
+        SQLComparisonFilter(IsGreaterThanOrEqualTo isGreaterThanOrEqualTo, BiFunction<String, SQLType, String> keyMapper) {
+            this(isGreaterThanOrEqualTo.key(), keyMapper, ">=", isGreaterThanOrEqualTo.comparisonValue(), false);
         }
 
-        SQLComparisonFilter(IsLessThan isLessThan, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isLessThan.key()), "<", isLessThan.comparisonValue(), false);
+        SQLComparisonFilter(IsLessThan isLessThan, BiFunction<String, SQLType, String> keyMapper) {
+            this(isLessThan.key(), keyMapper, "<", isLessThan.comparisonValue(), false);
         }
 
-        SQLComparisonFilter(IsLessThanOrEqualTo isLessThanOrEqualTo, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isLessThanOrEqualTo.key()), "<=", isLessThanOrEqualTo.comparisonValue(), false);
+        SQLComparisonFilter(IsLessThanOrEqualTo isLessThanOrEqualTo, BiFunction<String, SQLType, String> keyMapper) {
+            this(isLessThanOrEqualTo.key(), keyMapper, "<=", isLessThanOrEqualTo.comparisonValue(), false);
         }
 
         /**
@@ -187,8 +199,12 @@ final class SQLFilters {
          * A null value is not equal to a non-null value.
          * </p>
          *
-         * @param identifier Identifier applied as the left side operand. This can be a simple column name, or can be
-         *                   SQL expression like "JSON_VALUE(...)". Not null.
+         * @param key Identifies the key applied as the left side operand. Not null.
+         *
+         * @param keyMapper Function which maps {@link dev.langchain4j.data.document.Metadata} keys to SQL identifiers.
+         *                  The SQL identifier can be a simple column name, or it can be a more complex expression, such
+         *                  as a call to the builtin "JSON_VALUE" function. This argument can not be null. The String
+         *                  passed to this function will not be null. This function must not return a null result.
          *
          * @param operator Operator between the left and right side operands. Not null.
          *
@@ -196,8 +212,11 @@ final class SQLFilters {
          *
          * @param isNullTrue Result of the filter when the metadata does not contain the key.
          */
-        private <T> SQLComparisonFilter(String identifier, String operator, T comparisonValue, boolean isNullTrue) {
-            this.sql = "NVL(" + identifier + " " + operator + " ?, " + isNullTrue + ")";
+        private <T> SQLComparisonFilter(
+                String key, BiFunction<String, SQLType, String> keyMapper, String operator, T comparisonValue,
+                boolean isNullTrue) {
+            this.sqlType = toSQLType(comparisonValue);
+            this.sql = "NVL(" + keyMapper.apply(key, sqlType) + " " + operator + " ?, " + isNullTrue + ")";
             this.comparisonValue = comparisonValue;
         }
 
@@ -208,7 +227,7 @@ final class SQLFilters {
 
         @Override
         public int setParameters(PreparedStatement preparedStatement, int parameterIndex) throws SQLException {
-            preparedStatement.setObject(parameterIndex, toJdbcObject(comparisonValue));
+            preparedStatement.setObject(parameterIndex, toJdbcObject(comparisonValue), sqlType);
             return 1;
         }
     }
@@ -243,15 +262,15 @@ final class SQLFilters {
          */
         private final String sql;
 
-        SQLLogicalFilter(And and, UnaryOperator<String> keyMapper) {
+        SQLLogicalFilter(And and, BiFunction<String, SQLType, String> keyMapper) {
             this(and.left(), "AND", and.right(), keyMapper);
         }
 
-        SQLLogicalFilter(Or or, UnaryOperator<String> keyMapper) {
+        SQLLogicalFilter(Or or, BiFunction<String, SQLType, String> keyMapper) {
             this(or.left(), "OR", or.right(), keyMapper);
         }
 
-        private SQLLogicalFilter(Filter left, String operator, Filter right, UnaryOperator<String> keyMapper) {
+        private SQLLogicalFilter(Filter left, String operator, Filter right, BiFunction<String, SQLType, String> keyMapper) {
             this(create(left, keyMapper), operator, create(right, keyMapper));
         }
 
@@ -288,7 +307,6 @@ final class SQLFilters {
      * NOT(age > ? AND age < ?)
      * </li></ul>
      * </p>
-     *
      */
     private static class SQLNot implements SQLFilter {
 
@@ -305,7 +323,7 @@ final class SQLFilters {
          */
         private final String sql;
 
-        SQLNot(Not not, UnaryOperator<String> keyMapper) {
+        SQLNot(Not not, BiFunction<String, SQLType, String> keyMapper) {
             this.expression = create(not.expression(), keyMapper);
             this.sql = "NOT(" + expression.toSQL() + ")";
         }
@@ -346,15 +364,21 @@ final class SQLFilters {
          */
         private final String sql;
 
+        /**
+         * The SQL data type that values are compared as. The IN or NOT clause will operate on a key value and
+         * {@link #comparisonValues} that are converted to this SQL type.
+         */
+        private final SQLType sqlType;
+
         /** The values to search within. These are set as the values for "?" parameter markers */
         private final Collection<?> comparisonValues;
 
-        SQLInFilter(IsIn isIn, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isIn.key()), true, isIn.comparisonValues());
+        SQLInFilter(IsIn isIn, BiFunction<String, SQLType, String> keyMapper) {
+            this(isIn.key(), keyMapper, true, isIn.comparisonValues());
         }
 
-        SQLInFilter(IsNotIn isNotIn, UnaryOperator<String> keyMapper) {
-            this(keyMapper.apply(isNotIn.key()), false, isNotIn.comparisonValues());
+        SQLInFilter(IsNotIn isNotIn, BiFunction<String, SQLType, String> keyMapper) {
+            this(isNotIn.key(), keyMapper, false, isNotIn.comparisonValues());
         }
 
         /**
@@ -366,16 +390,23 @@ final class SQLFilters {
          * IN condition, and FALSE for an IN condition.
          * </p>
          *
-         * @param identifier Identifier applied as the left side operand. This can be a simple column name, or can be
-         *                   SQL expression like "JSON_VALUE(...)". Not null.
+         * @param key Identifies the key applied as the left side operand. Not null.
+         *
+         * @param keyMapper Function which maps {@link dev.langchain4j.data.document.Metadata} keys to SQL identifiers.
+         *                  The SQL identifier can be a simple column name, or it can be a more complex expression, such
+         *                  as a call to the builtin "JSON_VALUE" function. This argument can not be null. The String
+         *                  passed to this function will not be null. This function must not return a null result.
          *
          * @param isIn <code>true</code> to construct an "IN" condition, or <code>false</code> to construct a "NOT IN"
          *             condition.
          *
-         * @param comparisonValues Set of values to search within. Not null.
+         * @param comparisonValues Set of values to search within. Not null. Not empty.
          */
-        private SQLInFilter(String identifier, boolean isIn, Collection<?> comparisonValues) {
-            this.sql = "NVL(" + identifier + (isIn ? " IN " : " NOT IN ") + "("
+        private SQLInFilter(
+                String key, BiFunction<String, SQLType, String> keyMapper, boolean isIn,
+                Collection<?> comparisonValues) {
+            this.sqlType = toSQLType(comparisonValues);
+            this.sql = "NVL(" + keyMapper.apply(key, sqlType) + (isIn ? " IN " : " NOT IN ") + "("
                     + Stream.generate(() -> "?")
                         .limit(comparisonValues.size())
                         .collect(Collectors.joining(", "))
@@ -392,7 +423,7 @@ final class SQLFilters {
         @Override
         public int setParameters(PreparedStatement preparedStatement, int parameterIndex) throws SQLException {
             for (Object object : comparisonValues) {
-                preparedStatement.setObject(parameterIndex++, toJdbcObject(object));
+                preparedStatement.setObject(parameterIndex++, toJdbcObject(object), sqlType);
             }
             return comparisonValues.size();
         }
@@ -426,9 +457,9 @@ final class SQLFilters {
     }
 
     /**
-     * Converts an object into one that can be passed to {@link PreparedStatement#setObject(int, Object)}. JDBC drivers
-     * are only required to support object types listed in the JDBC Specification, and this may not include all object
-     * types supported by {@link Metadata}. Namely, {@link UUID}.
+     * Converts an object into one that can be passed to {@link PreparedStatement#setObject(int, Object, SQLType)}.
+     * JDBC drivers are only required to support object types listed in the JDBC Specification, and this may not
+     * include all object types supported by {@link Metadata}. Namely, {@link UUID}.
      *
      * @param object Object to convert. May be null.
      * @return The converted object, or the same object if no conversion is required. May be null.
@@ -438,5 +469,70 @@ final class SQLFilters {
             return object.toString();
 
         return object;
+    }
+
+    /**
+     * <p>
+     * Returns the SQL data type that a filter should use when binding a collection of objects with
+     * {@link PreparedStatement#setObject(int, Object, SQLType)}, where all objects will be compared to a key value.
+     * This method only checks for classes of objects which are supported by {@link Metadata}, as a {@link Filter} is
+     * only supposed to operate on the values of a Metadata object.
+     * </p><p>
+     * This method will throw an IllegalArgumentException if the Collection contains objects of different classes, such
+     * as {@code List.of("a", 0, 1.1d)}. It is not clear if users actually need that case to be supported or not. It
+     * is possible to construct an IsIn or IsNotIn Filter with such a Collection, and the Filters do support it.
+     * However, there are no tests which verify such a case, so it is thought that it might not be required. If this
+     * case does need to be supported, consider decomposing the SQL IN or NOT IN expressions into multiple OR or AND
+     * expressions, with each expression using a different SQL type.
+     * </p>
+     * @param objects Collection of objects that are converted into SQL data types. Not null. Not empty.
+     * @return The SQL data type to convert objects into. Not null.
+     */
+    static SQLType toSQLType(Collection<?> objects) {
+        Set<SQLType> jdbcTypes =
+            objects.stream()
+                    .map(SQLFilters::toSQLType)
+                    .collect(Collectors.toSet());
+
+        // Not supporting the case where a collection contains different classes of objects.
+        if (jdbcTypes.size() != 1) {
+            throw new IllegalArgumentException(
+                    "Filters comparing a Collection of non-uniform object classes are not supported. The Collection " +
+                            "contains objects of the following classes: " +
+                    objects.stream()
+                            .map(Object::getClass)
+                            .map(Class::getSimpleName)
+                            .collect(Collectors.joining(", ")));
+        }
+
+        return jdbcTypes.iterator().next();
+    }
+
+    /**
+     * Returns the SQL data type that a filter should use when binding an object with
+     * {@link PreparedStatement#setObject(int, Object, SQLType)}. This method only checks for classes of objects which
+     * are supported by {@link Metadata}, as a {@link Filter} is only supposed to operate on the values of a Metadata
+     * object.
+     *
+     * @param object Object that is converted into a SQL data type. Not null. Not empty.
+     * @return The SQL data type to convert object into. Not null.
+     */
+    static SQLType toSQLType(Object object) {
+        if (object instanceof Number) {
+            if (object instanceof Float)
+                return JDBCType.REAL; // REAL with default precision is a 32-bit floating point number
+            else if (object instanceof Double)
+                return JDBCType.FLOAT; // FLOAT with default precision is a 64-bit floating point number
+            else if (object instanceof Integer)
+                return JDBCType.INTEGER;
+            else
+                return JDBCType.NUMERIC; // NUMERIC is an integer with 38 decimal digits
+        }
+        else {
+            // Compare null, String, UUID, and any other object that Metadata supports in the future as VARCHAR objects.
+            // It is assumed that the getOsonFromMetadata object method in OracleEmbeddingStore will convert these
+            // objects to String. A VARCHAR can store the information of a Java String without losing any information.
+            return JDBCType.VARCHAR;
+        }
     }
 }

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/CommonTestOperations.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.logging.Logger;
 
@@ -86,8 +87,7 @@ final class CommonTestOperations {
                 DATA_SOURCE.setPassword(System.getenv("ORACLE_JDBC_PASSWORD"));
             }
 
-        } catch (
-                SQLException sqlException) {
+        } catch (SQLException sqlException) {
             throw new AssertionError(sqlException);
         }
     }

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/SQLFilterTest.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/SQLFilterTest.java
@@ -1,0 +1,104 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.MetadataFilterBuilder;
+import dev.langchain4j.store.embedding.filter.comparison.*;
+import org.junit.jupiter.api.Test;
+
+import java.sql.JDBCType;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that {@link SQLFilter} behaves as specified in its JavaDoc. The
+ * {@link dev.langchain4j.store.embedding.EmbeddingStoreWithFilteringIT} test already covers many cases. This test class
+ * covers some additional behavior which that test might not check for.
+ */
+public class SQLFilterTest {
+
+    /**
+     * Verifies the case where an IsIn and IsNot in filter has a comparison values of different object classes.
+     */
+    @Test
+    public void testNonUniformCollection() {
+        Collection<?> objects = Stream.of(
+                Integer.MIN_VALUE, Long.MAX_VALUE, Float.MIN_VALUE, Double.MAX_VALUE, "test")
+                .collect(Collectors.toList());
+
+        verifyNonUniformCollectionException(new IsIn("x", objects));
+        verifyNonUniformCollectionException(new IsNotIn("x", objects));
+    }
+
+    private void verifyNonUniformCollectionException(Filter filter) {
+        String message = assertThrows(
+                IllegalArgumentException.class,
+                () -> SQLFilters.create(filter, (key, type) -> ""))
+                .getMessage();
+
+        Collection<?> objects = filter instanceof IsIn
+                ? ((IsIn)filter).comparisonValues()
+                : ((IsNotIn)filter).comparisonValues(); // <-- Need to add a new case if testing a new Filter class
+
+        for (Object object : objects) {
+            assertTrue(message.contains(object == null ? "null" : object.getClass().getSimpleName()));
+        }
+    }
+
+    /**
+     * Verifies the SQLType that is resolved for each Java object type, along with the SQL expression returned by
+     * {@link SQLFilter#toSQL()}.
+     */
+    @Test
+    public void testSQLType() {
+        assertEquals(
+                "NVL(x = ?, false)",
+                SQLFilters.create(new IsEqualTo("x", Integer.MIN_VALUE), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.INTEGER, type);
+                    return key;
+                }).toSQL());
+
+        assertEquals(
+                "NVL(x <> ?, true)",
+                SQLFilters.create(new IsNotEqualTo("x", Long.MAX_VALUE), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.NUMERIC, type);
+                    return key;
+                }).toSQL());
+
+        assertEquals(
+                "NVL(x > ?, false)",
+                SQLFilters.create(new IsGreaterThan("x", 0.0f), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.REAL, type); // REAL is 32-bit floating point
+                    return key;
+                }).toSQL());
+
+        assertEquals(
+                "NVL(x < ?, false)",
+                SQLFilters.create(new IsLessThan("x", 0.0d), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.FLOAT, type); // FLOAT is 64-bit floating point
+                    return key;
+                }).toSQL());
+
+        assertEquals(
+                "NVL(x IN (?, ?), false)",
+                SQLFilters.create(MetadataFilterBuilder.metadataKey("x").isIn(0, 1), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.INTEGER, type);
+                    return key;
+                }).toSQL());
+
+        assertEquals(
+                "NVL(x NOT IN (?, ?), true)",
+                SQLFilters.create(MetadataFilterBuilder.metadataKey("x").isNotIn("a", "b"), (key, type) -> {
+                    assertEquals("x", key);
+                    assertEquals(JDBCType.VARCHAR, type);
+                    return key;
+                }).toSQL());
+    }
+}


### PR DESCRIPTION
Fixes an issue where an ORA-01722 error would arise from filtering of numeric values. This issue was originally found in our PR for the forked repo: https://github.com/langchain4j/langchain4j/pull/1490#issuecomment-2301369867

Here's this error happens:

1. When Oracle JDBC logs in to a database, it first reads the value of java.util.Locale.getDefault(Category.FORMAT). It then configures the database session to have the NLS_TERRITORY parameter set to this Locale.

2. By default, the JSON_VALUE function returns a VARCHAR. I had overlooked this when I originally wrote the SQLFilter code. Today, I took a closer look at the docs, and I learned that we need to add a RETURNING clause to have JSON_VALUE return a type other than VARCHAR. Reference:
  "Use the RETURNING clause to specify the data type of the return value. If you omit this clause, then JSON_VALUE returns a value of type VARCHAR2(4000)."
  https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/JSON_VALUE.html#GUID-C7F19D36-1E75-4CB2-AE67-ADFBAD23CBC2
  It seems like JSON_VALUE is not respecting the NLS_TERRITORY setting, and returns a VARCHAR with numbers formatted for the United States, where '.' is a decimal separator.
  I think the JSON_VALUE behavior is a bug, so I'll be filing a report for that.

3. When a comparison operator, like "=", operates on a VARCHAR and numeric value, the database converts the VARCHAR into the same type as the numeric value. Reference:
  "During arithmetic operations on and comparisons between character and noncharacter data types, Oracle converts from any character data type to a numeric, date, or rowid, as appropriate. In arithmetic operations between CHAR/VARCHAR2 and NCHAR/NVARCHAR2, Oracle converts to a NUMBER."
  https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Type-Comparison-Rules.html#GUID-98BE3A78-6E33-4181-B5CB-D96FD9DC1694
  At this step, Oracle Database throws an error because the numeric value does not match the NLS_TERRITORY format that JDBC set.

4. Recall that JSON_VALUE does not respect the NLS_TERRITORY parameter when converting a numeric to a VARCHAR. So it might output '1.23'. If the territory parameter is one where ',' is decimal separator, the database raises ORA-01722 because it won't recognize '.'.

The fix is to add a RETURNING clause in our JSON_VALUE function call. The RETURNING clause will prevent conversions of numeric values to VARCHAR, and instead convert them to REAL, FLOAT, INTEGER, or NUMERIC. Not only does this fix the issue, it also eliminates the performance cost of a useless conversion from numeric value, to VARCHAR value, back to numeric value.
The fix required some changes to SQLFilter. The SQL expressions will now be explicit about the data type of bind values and the value extracted from JSON_VALUE.

I verified this fix by running all tests with the following configurations:
1. Set the JVM locale to France
  1.1. Setup the database with the default '.' decimal seperator.
  1.2. Setup the database with  ',' as a decimal separtor.
2. Set the JVM locale to US
  2.1. Setup the database with the default '.' decimal seperator.
  2.2. Setup the database with  ',' as a decimal separtor