### PR TITLE
Fixed potential breaking changes

### DIFF
--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/CreateOption.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/CreateOption.java
@@ -6,7 +6,7 @@ package dev.langchain4j.store.embedding.oracle;
 public enum CreateOption {
 
     /** No attempt is made to create the schema object. */
-    DO_NOT_CREATE,
+    CREATE_NONE,
 
     /** An existing schema object is reused, otherwise it is created. */
     CREATE_IF_NOT_EXISTS,

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/Index.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/Index.java
@@ -1,11 +1,11 @@
 package dev.langchain4j.store.embedding.oracle;
 
-import javax.sql.DataSource;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-
-import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import javax.sql.DataSource;
 
 /**
  * <p>
@@ -27,85 +27,84 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
  */
 public class Index {
 
-  /**
-   * The index builder.
-   */
-  private IndexBuilder builder;
+    /**
+     * The index builder.
+     */
+    private IndexBuilder builder;
 
-  /**
-   * The name of the table.
-   */
-  private String tableName;
+    /**
+     * The name of the table.
+     */
+    private String tableName;
 
-  /**
-   * Create an index.
-   * @param builder The builder.
-   */
-  Index(IndexBuilder builder) {
-    this.builder = builder;
-  }
-
-  /**
-   * Creates a builder to configure an IVF index on the embedding column of
-   * the {@link EmbeddingTable}.
-   * @return A builder that allows to configure an IVF index.
-   */
-  public static IVFIndexBuilder ivfIndexBuilder() {
-    return new IVFIndexBuilder();
-  }
-
-  /**
-   * Creates a builder to configure a function-based index on one or several
-   * keys of the metadata column of the {@link EmbeddingTable}.
-   * @return A builder that allows to configure an index on the metadata
-   * column.
-   */
-  public static JSONIndexBuilder jsonIndexBuilder() {
-    return new JSONIndexBuilder();
-  }
-
-  /**
-   * Returns the name of the index.
-   *
-   * @return The name of the index or null if the name has not been set and the index
-   * has not been created.
-   */
-  public String name() {
-    return builder.indexName;
-  }
-
-  /**
-   * Returns the name of this table.
-   *
-   * @return Once the index has been created it returns the table name, otherwise it
-   * returns null.
-   */
-  public String tableName() {
-    return tableName;
-  }
-
-  /**
-   * Creates the index.
-   * @param dataSource The datasource.
-   * @param embeddingTable The embedding table.
-   * @throws SQLException If an error occurs while creating the index.
-   */
-  void create(DataSource dataSource, EmbeddingTable embeddingTable) throws SQLException {
-
-    ensureNotNull(dataSource,"dataSource");
-    ensureNotNull(embeddingTable, "embeddingTable");
-
-    this.tableName = embeddingTable.name();
-
-    if (builder.createOption == CreateOption.DO_NOT_CREATE) return;
-    try (Connection connection = dataSource.getConnection();
-         Statement statement = connection.createStatement()) {
-      if (builder.createOption == CreateOption.CREATE_OR_REPLACE) {
-        statement.addBatch(builder.getDropIndexStatement(embeddingTable));
-      }
-      statement.addBatch(builder.getCreateIndexStatement(embeddingTable));
-      statement.executeBatch();
+    /**
+     * Create an index.
+     * @param builder The builder.
+     */
+    Index(IndexBuilder builder) {
+        this.builder = builder;
     }
-  }
 
+    /**
+     * Creates a builder to configure an IVF index on the embedding column of
+     * the {@link EmbeddingTable}.
+     * @return A builder that allows to configure an IVF index.
+     */
+    public static IVFIndexBuilder ivfIndexBuilder() {
+        return new IVFIndexBuilder();
+    }
+
+    /**
+     * Creates a builder to configure a function-based index on one or several
+     * keys of the metadata column of the {@link EmbeddingTable}.
+     * @return A builder that allows to configure an index on the metadata
+     * column.
+     */
+    public static JSONIndexBuilder jsonIndexBuilder() {
+        return new JSONIndexBuilder();
+    }
+
+    /**
+     * Returns the name of the index.
+     *
+     * @return The name of the index or null if the name has not been set and the index
+     * has not been created.
+     */
+    public String name() {
+        return builder.indexName;
+    }
+
+    /**
+     * Returns the name of this table.
+     *
+     * @return Once the index has been created it returns the table name, otherwise it
+     * returns null.
+     */
+    public String tableName() {
+        return tableName;
+    }
+
+    /**
+     * Creates the index.
+     * @param dataSource The datasource.
+     * @param embeddingTable The embedding table.
+     * @throws SQLException If an error occurs while creating the index.
+     */
+    void create(DataSource dataSource, EmbeddingTable embeddingTable) throws SQLException {
+
+        ensureNotNull(dataSource, "dataSource");
+        ensureNotNull(embeddingTable, "embeddingTable");
+
+        this.tableName = embeddingTable.name();
+
+        if (builder.createOption == CreateOption.CREATE_NONE) return;
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            if (builder.createOption == CreateOption.CREATE_OR_REPLACE) {
+                statement.addBatch(builder.getDropIndexStatement(embeddingTable));
+            }
+            statement.addBatch(builder.getCreateIndexStatement(embeddingTable));
+            statement.executeBatch();
+        }
+    }
 }

--- a/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/IndexBuilder.java
+++ b/langchain4j-oracle/src/main/java/dev/langchain4j/store/embedding/oracle/IndexBuilder.java
@@ -14,118 +14,117 @@ import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
  * @param <T> The index builder's type.
  */
 abstract class IndexBuilder<T extends IndexBuilder> {
-  static final int INDEX_NAME_MAX_LENGTH = 128;
+    static final int INDEX_NAME_MAX_LENGTH = 128;
 
-  /**
-   * The name of the index, or null if no name was set.
-   */
-  protected String indexName;
+    /**
+     * The name of the index, or null if no name was set.
+     */
+    protected String indexName;
 
-  /**
-   * CreateOption for the index. By default, the index will not be created.
-   */
-  CreateOption createOption = CreateOption.DO_NOT_CREATE;
+    /**
+     * CreateOption for the index. By default, the index will not be created.
+     */
+    CreateOption createOption = CreateOption.CREATE_NONE;
 
-  /**
-   * Configures the option to create (or not create) an index. The default is
-   * {@link CreateOption#CREATE_IF_NOT_EXISTS}, which means that an index will
-   * be created if an index with the same name does not already exist.
-   *
-   * @param createOption The create option.
-   *
-   * @return This builder.
-   *
-   * @throws IllegalArgumentException If createOption is null.
-   */
-  public T createOption(CreateOption createOption) {
-    ensureNotNull(createOption, "createOption");
-    this.createOption = createOption;
-    return (T) this;
-  }
-
-  /**
-   * Sets the index name.
-   * @param indexName The name of the index.
-   * @return This builder.
-   */
-  public T name(String indexName) {
-    this.indexName = indexName;
-    return (T) this;
-  }
-
-  /**
-   * Creates an index name given the table name and a suffix.
-   * @param tableName The table name.
-   * @param suffix The index suffix.
-   * @return The index name.
-   */
-  String buildIndexName(String tableName, String suffix) {
-    boolean isQuoted =  tableName.startsWith("\"") && tableName.endsWith("\"");
-    // If the table name is a quoted identifier, then the index name must also be quoted.
-    if (isQuoted) {
-      tableName = unquoteTableName(tableName);
+    /**
+     * Configures the option to create (or not create) an index. The default is
+     * {@link CreateOption#CREATE_IF_NOT_EXISTS}, which means that an index will
+     * be created if an index with the same name does not already exist.
+     *
+     * @param createOption The create option.
+     *
+     * @return This builder.
+     *
+     * @throws IllegalArgumentException If createOption is null.
+     */
+    public T createOption(CreateOption createOption) {
+        ensureNotNull(createOption, "createOption");
+        this.createOption = createOption;
+        return (T) this;
     }
-    indexName = truncateIndexName(tableName + suffix, isQuoted);
-    if (isQuoted) {
-      indexName = "\"" + indexName + "\"";
+
+    /**
+     * Sets the index name.
+     * @param indexName The name of the index.
+     * @return This builder.
+     */
+    public T name(String indexName) {
+        this.indexName = indexName;
+        return (T) this;
     }
-    return indexName;
-  }
 
-  /**
-   * Truncates the index name if it os longer that the maximum length allowed
-   * by the database.
-   * @param indexName The index name.
-   * @param isQuoted True if the index name is quoted.
-   * @return The index name truncated to the max length allowed by the database.
-   */
-  private String truncateIndexName(String indexName, boolean isQuoted) {
-    int maxLength = isQuoted ? INDEX_NAME_MAX_LENGTH - 2 : INDEX_NAME_MAX_LENGTH;
-    if (indexName.length() > maxLength) {
-      indexName = indexName.substring(0, maxLength);
+    /**
+     * Creates an index name given the table name and a suffix.
+     * @param tableName The table name.
+     * @param suffix The index suffix.
+     * @return The index name.
+     */
+    String buildIndexName(String tableName, String suffix) {
+        boolean isQuoted = tableName.startsWith("\"") && tableName.endsWith("\"");
+        // If the table name is a quoted identifier, then the index name must also be quoted.
+        if (isQuoted) {
+            tableName = unquoteTableName(tableName);
+        }
+        indexName = truncateIndexName(tableName + suffix, isQuoted);
+        if (isQuoted) {
+            indexName = "\"" + indexName + "\"";
+        }
+        return indexName;
     }
-    return indexName;
-  }
 
-  /**
-   * Unquote the table name.
-   * @param tableName The table name.
-   * @return The unquoted table name.
-   */
-  private String unquoteTableName(String tableName) {
-    return tableName.substring(1, tableName.length() - 1);
-  }
+    /**
+     * Truncates the index name if it os longer that the maximum length allowed
+     * by the database.
+     * @param indexName The index name.
+     * @param isQuoted True if the index name is quoted.
+     * @return The index name truncated to the max length allowed by the database.
+     */
+    private String truncateIndexName(String indexName, boolean isQuoted) {
+        int maxLength = isQuoted ? INDEX_NAME_MAX_LENGTH - 2 : INDEX_NAME_MAX_LENGTH;
+        if (indexName.length() > maxLength) {
+            indexName = indexName.substring(0, maxLength);
+        }
+        return indexName;
+    }
 
-  /**
-   * Builds the index object configured by this builder.
-   * @return The index object.
-   */
-  public abstract Index build();
+    /**
+     * Unquote the table name.
+     * @param tableName The table name.
+     * @return The unquoted table name.
+     */
+    private String unquoteTableName(String tableName) {
+        return tableName.substring(1, tableName.length() - 1);
+    }
 
-  /**
-   * Returns the <em>CREATE INDEX</em> SQL statement of the configured index given
-   * the embedding table.
-   * @param embeddingTable The embedding table.
-   * @return The <em>CREATE INDEX</em> SQL statement.
-   */
-  abstract String getCreateIndexStatement(EmbeddingTable embeddingTable);
+    /**
+     * Builds the index object configured by this builder.
+     * @return The index object.
+     */
+    public abstract Index build();
 
-  /**
-   * Returns the <em>DROP INDEX</em> SQL statement of the configured index given
-   * the embedding table.
-   * @param embeddingTable The embedding table.
-   * @return The <em>DROP INDEX</em> SQL statement.
-   */
-  String getDropIndexStatement(EmbeddingTable embeddingTable) {
+    /**
+     * Returns the <em>CREATE INDEX</em> SQL statement of the configured index given
+     * the embedding table.
+     * @param embeddingTable The embedding table.
+     * @return The <em>CREATE INDEX</em> SQL statement.
+     */
+    abstract String getCreateIndexStatement(EmbeddingTable embeddingTable);
 
-    return "DROP INDEX IF EXISTS " + getIndexName(embeddingTable);
-  }
+    /**
+     * Returns the <em>DROP INDEX</em> SQL statement of the configured index given
+     * the embedding table.
+     * @param embeddingTable The embedding table.
+     * @return The <em>DROP INDEX</em> SQL statement.
+     */
+    String getDropIndexStatement(EmbeddingTable embeddingTable) {
 
-  /**
-   * Returns the name of the index, if a name has not been set, the name is generated.
-   * @param embeddingTable The embedding table.
-   * @return The index name.
-   */
-  abstract String getIndexName(EmbeddingTable embeddingTable);
+        return "DROP INDEX IF EXISTS " + getIndexName(embeddingTable);
+    }
 
+    /**
+     * Returns the name of the index, if a name has not been set, the name is generated.
+     * @param embeddingTable The embedding table.
+     * @return The index name.
+     */
+    abstract String getIndexName(EmbeddingTable embeddingTable);
 }

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingIndexStoreWithFilteringIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingIndexStoreWithFilteringIT.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+public class EmbeddingIndexStoreWithFilteringIT extends OracleEmbeddingStoreWithFilteringIT {
+
+    private final OracleEmbeddingStore embeddingStore = CommonTestOperations.newEmbeddingStoreBuilder()
+            .index(Index.ivfIndexBuilder()
+                    .createOption(CreateOption.CREATE_OR_REPLACE)
+                    .build())
+            .build();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+}

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingIndexStoreWithRemovalIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingIndexStoreWithRemovalIT.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+public class EmbeddingIndexStoreWithRemovalIT extends OracleEmbeddingStoreWithRemovalIT {
+
+    private final OracleEmbeddingStore embeddingStore = CommonTestOperations.newEmbeddingStoreBuilder()
+            .index(Index.ivfIndexBuilder()
+                    .createOption(CreateOption.CREATE_OR_REPLACE)
+                    .build())
+            .build();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+}

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingTableIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/EmbeddingTableIT.java
@@ -1,27 +1,26 @@
 package dev.langchain4j.store.embedding.oracle;
 
-import dev.langchain4j.data.embedding.Embedding;
-import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
-import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
-import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
-import dev.langchain4j.store.embedding.filter.logical.And;
-import oracle.jdbc.OracleType;
-import org.junit.jupiter.api.Test;
-
-import java.sql.*;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static dev.langchain4j.store.embedding.oracle.CommonTestOperations.dropTable;
 import static dev.langchain4j.store.embedding.oracle.CommonTestOperations.getDataSource;
 import static dev.langchain4j.store.embedding.oracle.CreateOption.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import dev.langchain4j.store.embedding.filter.comparison.IsNotEqualTo;
+import dev.langchain4j.store.embedding.filter.logical.And;
+import java.sql.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import oracle.jdbc.OracleType;
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies {@link OracleEmbeddingStore.Builder} methods which configure the names of columns.
@@ -41,25 +40,23 @@ public class EmbeddingTableIT {
         String metadataColumn = "TEST_METADATA";
         try {
             // The call to build() should create a table with the configured names
-            OracleEmbeddingStore embeddingStore =
-                OracleEmbeddingStore.builder()
-                        .dataSource(getDataSource())
-                        .embeddingTable(EmbeddingTable.builder()
-                                .createOption(CREATE_OR_REPLACE)
-                                .name(tableName)
-                                .idColumn(idColumn)
-                                .embeddingColumn(embeddingColumn)
-                                .textColumn(textColumn)
-                                .metadataColumn(metadataColumn)
-                                .build())
-                        // Verify interactions with the CREATE INDEX command
-                        .index(Index.ivfIndexBuilder().createOption(CREATE_OR_REPLACE).build())
-                        .build();
+            OracleEmbeddingStore embeddingStore = OracleEmbeddingStore.builder()
+                    .dataSource(getDataSource())
+                    .embeddingTable(EmbeddingTable.builder()
+                            .createOption(CREATE_OR_REPLACE)
+                            .name(tableName)
+                            .idColumn(idColumn)
+                            .embeddingColumn(embeddingColumn)
+                            .textColumn(textColumn)
+                            .metadataColumn(metadataColumn)
+                            .build())
+                    // Verify interactions with the CREATE INDEX command
+                    .vectorIndex(CREATE_OR_REPLACE)
+                    .build();
 
             assertColumnNamesEquals(tableName, idColumn, embeddingColumn, textColumn, metadataColumn);
             verifyAddSearchAndRemove(embeddingStore);
-        }
-        finally {
+        } finally {
             CommonTestOperations.dropTable(tableName);
         }
     }
@@ -79,24 +76,22 @@ public class EmbeddingTableIT {
         String metadataColumn = "البيانات الوصفية";
         try {
             // Oracle Database supports non-ascii identifiers wrapped in double quotes.
-            OracleEmbeddingStore embeddingStore =
-                OracleEmbeddingStore.builder()
-                        .dataSource(getDataSource())
-                        .embeddingTable(EmbeddingTable.builder()
-                                .createOption(CREATE_OR_REPLACE)
-                                .name("\"" + tableName +"\"")
-                                .idColumn("\"" + idColumn + "\"")
-                                .embeddingColumn("\"" + embeddingColumn + "\"")
-                                .textColumn("\"" + textColumn + "\"")
-                                .metadataColumn("\"" + metadataColumn + "\"")
-                                .build())
-                        // CREATE INDEX fails with lower case Unicode names
-                        .build();
+            OracleEmbeddingStore embeddingStore = OracleEmbeddingStore.builder()
+                    .dataSource(getDataSource())
+                    .embeddingTable(EmbeddingTable.builder()
+                            .createOption(CREATE_OR_REPLACE)
+                            .name("\"" + tableName + "\"")
+                            .idColumn("\"" + idColumn + "\"")
+                            .embeddingColumn("\"" + embeddingColumn + "\"")
+                            .textColumn("\"" + textColumn + "\"")
+                            .metadataColumn("\"" + metadataColumn + "\"")
+                            .build())
+                    // CREATE INDEX fails with lower case Unicode names
+                    .build();
 
             assertColumnNamesEquals(tableName, idColumn, embeddingColumn, textColumn, metadataColumn);
             verifyAddSearchAndRemove(embeddingStore);
-        }
-        finally {
+        } finally {
             dropTable(tableName);
         }
     }
@@ -116,25 +111,23 @@ public class EmbeddingTableIT {
         String metadataColumn = "البيانات الوصفية".toUpperCase();
         try {
             // Oracle Database supports non-ascii identifiers wrapped in double quotes.
-            OracleEmbeddingStore embeddingStore =
-                OracleEmbeddingStore.builder()
+            OracleEmbeddingStore embeddingStore = OracleEmbeddingStore.builder()
                     .dataSource(getDataSource())
                     .embeddingTable(EmbeddingTable.builder()
-                        .createOption(CREATE_OR_REPLACE)
-                        .name("\"" + tableName +"\"")
-                        .idColumn("\"" + idColumn + "\"")
-                        .embeddingColumn("\"" + embeddingColumn + "\"")
-                        .textColumn("\"" + textColumn + "\"")
-                        .metadataColumn("\"" + metadataColumn + "\"")
-                        .build())
+                            .createOption(CREATE_OR_REPLACE)
+                            .name("\"" + tableName + "\"")
+                            .idColumn("\"" + idColumn + "\"")
+                            .embeddingColumn("\"" + embeddingColumn + "\"")
+                            .textColumn("\"" + textColumn + "\"")
+                            .metadataColumn("\"" + metadataColumn + "\"")
+                            .build())
                     // Verify interactions with the CREATE INDEX command
-                    .index(Index.ivfIndexBuilder().createOption(CREATE_OR_REPLACE).build())
+                    .vectorIndex(CREATE_OR_REPLACE)
                     .build();
 
             assertColumnNamesEquals(tableName, idColumn, embeddingColumn, textColumn, metadataColumn);
             verifyAddSearchAndRemove(embeddingStore);
-        }
-        finally {
+        } finally {
             dropTable(tableName);
         }
     }
@@ -162,7 +155,7 @@ public class EmbeddingTableIT {
                 OracleEmbeddingStore.builder()
                         .dataSource(getDataSource())
                         .embeddingTable(EmbeddingTable.builder()
-                                .createOption(DO_NOT_CREATE)
+                                .createOption(CREATE_NONE)
                                 .name(tableName)
                                 .build())
                         .build()
@@ -176,10 +169,9 @@ public class EmbeddingTableIT {
                     .dataSource(getDataSource())
                     .embeddingTable(tableName)
                     // Verify interactions with the CREATE INDEX command
-                    .index(Index.ivfIndexBuilder().createOption(CREATE_OR_REPLACE).build())
+                    .vectorIndex(CREATE_OR_REPLACE)
                     .build());
-        }
-        finally {
+        } finally {
             dropTable(tableName);
         }
     }
@@ -199,12 +191,11 @@ public class EmbeddingTableIT {
                     .build());
 
             // Set up the existing table to have just one row of data
-            TestData testData =
-                    new TestData(TestData.randomId(), TestData.randomEmbedding(), TextSegment.from("TEST"));
+            TestData testData = new TestData(TestData.randomId(), TestData.randomEmbedding(), TextSegment.from("TEST"));
             try (Connection connection = getDataSource().getConnection();
-                 Statement statement = connection.createStatement();
-                 PreparedStatement insert = connection.prepareStatement(
-                         "INSERT INTO " + tableName + "(id, embedding, text) VALUES (?, ?, ?)")) {
+                    Statement statement = connection.createStatement();
+                    PreparedStatement insert = connection.prepareStatement(
+                            "INSERT INTO " + tableName + "(id, embedding, text) VALUES (?, ?, ?)")) {
 
                 statement.execute("DELETE FROM " + tableName);
 
@@ -215,22 +206,20 @@ public class EmbeddingTableIT {
             }
 
             // Expect the existing table to be reused; A search of min score 0 should return 1 match.
-            List<TestData> matches =
-                OracleEmbeddingStore.builder()
-                        .dataSource(getDataSource())
-                        .embeddingTable(tableName, CREATE_IF_NOT_EXISTS)
-                        .build()
-                        .search(EmbeddingSearchRequest.builder()
-                                .queryEmbedding(testData.embedding)
-                                .minScore(0d)
-                                .build())
-                        .matches()
-                        .stream()
-                        .map(TestData::new)
-                        .collect(Collectors.toList());
+            List<TestData> matches = OracleEmbeddingStore.builder()
+                    .dataSource(getDataSource())
+                    .embeddingTable(tableName, CREATE_IF_NOT_EXISTS)
+                    .build()
+                    .search(EmbeddingSearchRequest.builder()
+                            .queryEmbedding(testData.embedding)
+                            .minScore(0d)
+                            .build())
+                    .matches()
+                    .stream()
+                    .map(TestData::new)
+                    .collect(Collectors.toList());
             assertThat(matches).isEqualTo(Collections.singletonList(testData));
-        }
-        finally {
+        } finally {
             dropTable(tableName);
         }
     }
@@ -252,9 +241,9 @@ public class EmbeddingTableIT {
             // Set up the existing table to have at least one row of data
             Embedding embedding = TestData.randomEmbedding();
             try (Connection connection = getDataSource().getConnection();
-                 Statement statement = connection.createStatement();
-                 PreparedStatement insert = connection.prepareStatement(
-                         "INSERT INTO " + tableName + "(id, embedding) VALUES (?, ?)")) {
+                    Statement statement = connection.createStatement();
+                    PreparedStatement insert =
+                            connection.prepareStatement("INSERT INTO " + tableName + "(id, embedding) VALUES (?, ?)")) {
 
                 insert.setString(1, TestData.randomId());
                 insert.setObject(2, embedding.vector(), OracleType.VECTOR);
@@ -262,23 +251,21 @@ public class EmbeddingTableIT {
             }
 
             // Expect the existing table to be dropped and replaced; A search of min score 0 should find no matches.
-            List<TestData> matches =
-                    OracleEmbeddingStore.builder()
-                            .dataSource(getDataSource())
-                            .embeddingTable(tableName, CREATE_OR_REPLACE)
-                            .build()
-                            .search(EmbeddingSearchRequest.builder()
-                                    .queryEmbedding(embedding)
-                                    .minScore(0d)
-                                    .build())
-                            .matches()
-                            .stream()
-                            .map(TestData::new)
-                            .collect(Collectors.toList());
+            List<TestData> matches = OracleEmbeddingStore.builder()
+                    .dataSource(getDataSource())
+                    .embeddingTable(tableName, CREATE_OR_REPLACE)
+                    .build()
+                    .search(EmbeddingSearchRequest.builder()
+                            .queryEmbedding(embedding)
+                            .minScore(0d)
+                            .build())
+                    .matches()
+                    .stream()
+                    .map(TestData::new)
+                    .collect(Collectors.toList());
             assertThat(matches).isEqualTo(Collections.emptyList());
 
-        }
-        finally {
+        } finally {
             dropTable(tableName);
         }
     }
@@ -300,9 +287,7 @@ public class EmbeddingTableIT {
                 .maxResults(expectedData.size())
                 .minScore(0.0)
                 .build();
-        Set<TestData> actualData = embeddingStore.search(requestAll)
-                .matches()
-                .stream()
+        Set<TestData> actualData = embeddingStore.search(requestAll).matches().stream()
                 .map(TestData::new)
                 .collect(Collectors.toSet());
 
@@ -313,12 +298,9 @@ public class EmbeddingTableIT {
 
         // Remove all embeddings
         embeddingStore.removeAll(
-                expectedData.stream()
-                    .map(testData -> testData.id)
-                    .collect(Collectors.toList()));
+                expectedData.stream().map(testData -> testData.id).collect(Collectors.toList()));
 
         assertThat(embeddingStore.search(requestAll).matches()).isEmpty();
-
     }
 
     /**
@@ -326,16 +308,15 @@ public class EmbeddingTableIT {
      * identifiers to upper case, unless they are enclosed in double quotes.
      */
     private static void assertColumnNamesEquals(
-            String tableName,
-            String idColumn, String embeddingColumn, String textColumn, String metadataColumn)
+            String tableName, String idColumn, String embeddingColumn, String textColumn, String metadataColumn)
             throws SQLException {
 
         Set<String> actualNames = new HashSet<>();
 
         // Query the database to get the column names
         try (Connection connection = getDataSource().getConnection();
-             ResultSet resultSet =
-                     connection.getMetaData().getColumns(null, connection.getSchema(), tableName, "%")) {
+                ResultSet resultSet =
+                        connection.getMetaData().getColumns(null, connection.getSchema(), tableName, "%")) {
             while (resultSet.next()) {
                 assertThat(resultSet.getString("TABLE_NAME")).isEqualTo(tableName);
                 actualNames.add(resultSet.getString("COLUMN_NAME"));
@@ -357,8 +338,7 @@ public class EmbeddingTableIT {
             // Expect "ORA-00942: table or view does not exist"  if the table does not exist
             SQLException sqlException = assertInstanceOf(SQLException.class, runtimeException.getCause());
             assertThat(sqlException.getErrorCode()).isEqualTo(942);
-        }
-        catch (AssertionError assertionError) {
+        } catch (AssertionError assertionError) {
             assertionError.addSuppressed(runtimeException);
             throw assertionError;
         }
@@ -367,10 +347,10 @@ public class EmbeddingTableIT {
     /** Creates a table with the default column names */
     private static void createTable(String tableName) throws SQLException {
         try (Connection connection = getDataSource().getConnection();
-             Statement statement = connection.createStatement()) {
+                Statement statement = connection.createStatement()) {
 
-            statement.execute("CREATE TABLE " + tableName +
-                    "(id VARCHAR(36) PRIMARY KEY, embedding VECTOR, text CLOB, metadata JSON)");
+            statement.execute("CREATE TABLE " + tableName
+                    + "(id VARCHAR(36) PRIMARY KEY, embedding VECTOR, text CLOB, metadata JSON)");
         }
     }
 }

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/MetadataAndEmbeddingIndexStoreWithFilteringIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/MetadataAndEmbeddingIndexStoreWithFilteringIT.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+public class MetadataAndEmbeddingIndexStoreWithFilteringIT extends OracleEmbeddingStoreWithFilteringIT {
+
+    private final OracleEmbeddingStore embeddingStore = CommonTestOperations.newEmbeddingStoreBuilder()
+            .index(
+                    Index.ivfIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .build(),
+                    Index.jsonIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .key("name", String.class, JSONIndexBuilder.Order.ASC)
+                            .build(),
+                    Index.jsonIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .key("age", Float.class, JSONIndexBuilder.Order.ASC)
+                            .build())
+            .build();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+}

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/MetadataAndEmbeddingIndexStoreWithRemovalIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/MetadataAndEmbeddingIndexStoreWithRemovalIT.java
@@ -1,0 +1,27 @@
+package dev.langchain4j.store.embedding.oracle;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+
+public class MetadataAndEmbeddingIndexStoreWithRemovalIT extends OracleEmbeddingStoreWithRemovalIT {
+
+    private final OracleEmbeddingStore embeddingStore = CommonTestOperations.newEmbeddingStoreBuilder()
+            .index(
+                    Index.ivfIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .build(),
+                    Index.jsonIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .key("name", String.class, JSONIndexBuilder.Order.ASC)
+                            .build(),
+                    Index.jsonIndexBuilder()
+                            .createOption(CreateOption.CREATE_OR_REPLACE)
+                            .key("age", Float.class, JSONIndexBuilder.Order.ASC)
+                            .build())
+            .build();
+
+    @Override
+    protected EmbeddingStore<TextSegment> embeddingStore() {
+        return embeddingStore;
+    }
+}

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreWithRemovalIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/store/embedding/oracle/OracleEmbeddingStoreWithRemovalIT.java
@@ -4,10 +4,9 @@ import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import dev.langchain4j.store.embedding.EmbeddingStoreWithRemovalIT;
+import java.sql.SQLException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-
-import java.sql.SQLException;
 
 public class OracleEmbeddingStoreWithRemovalIT extends EmbeddingStoreWithRemovalIT {
 
@@ -17,7 +16,7 @@ public class OracleEmbeddingStoreWithRemovalIT extends EmbeddingStoreWithRemoval
     public void clearTable() {
         //  A removeAll call happens before each test because EmbeddingStoreWithRemovalIT is designed for each test to
         //  begin with an empty store.
-        EMBEDDING_STORE.removeAll();
+        embeddingStore().removeAll();
     }
 
     @Override


### PR DESCRIPTION
Current changes should fix: 

**Potential Breaking Changes**
1.	⚠️ The vectorIndex method in the OracleEmbeddingStore.Builder has been replaced with the index method, which accepts an array of Index objects. This change will break existing code that uses the vectorIndex method.
2.	The CREATE_NONE enum value in CreateOption has been renamed to DO_NOT_CREATE. This change will break existing code that uses the CREATE_NONE enum value.

I will look into the **suggested test scenarios** to see if there are scenarios that we should add.