### PR TITLE
Address PR comments

### DIFF
--- a/langchain4j-oracle/pom.xml
+++ b/langchain4j-oracle/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <jdbc.version>23.5.0.24.07</jdbc.version>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <dependencies>

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/model/oracle/OracleEmbeddingModelIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/model/oracle/OracleEmbeddingModelIT.java
@@ -11,11 +11,15 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class OracleEmbeddingModelIT extends OracleContainerTestBase {
 
+    // NB: Test requires ALL-MINILM-L6-V2.onnx to be downloaded
+    // and copied into the resource dir /models
+    @Disabled("Run test manually")
     @Test
     @DisplayName("embed with provider=database")
     void testEmbedONNX() throws SQLException {

--- a/langchain4j-oracle/src/test/java/dev/langchain4j/model/oracle/OracleIngestIT.java
+++ b/langchain4j-oracle/src/test/java/dev/langchain4j/model/oracle/OracleIngestIT.java
@@ -24,11 +24,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class OracleIngestIT extends OracleContainerTestBase {
 
+    // NB: Test requires ALL-MINILM-L6-V2.onnx to be downloaded
+    // and copied into the resource dir /models
+    @Disabled("Run test manually")
     @Test
     @DisplayName("ingest")
     void testIngest() throws IOException, SQLException, URISyntaxException {

--- a/langchain4j-oracle/src/test/resources/models/ALL-MINILM-L6-V2.onnx
+++ b/langchain4j-oracle/src/test/resources/models/ALL-MINILM-L6-V2.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b56179ffea24df29f6ff609bda5d46f05fde72421df34b0bd6a960ad7dff2ef
-size 90627961


### PR DESCRIPTION
Update compiler to 17
Remove ONNX file since it is too big for download
Disable ONNX tests until we update to automatically download the model. They can be run manually.
